### PR TITLE
Fix for quirky USART baud rate behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ created by the compiler before linking) to the `OBJS` list in the Makefile.
 
 ## Notes
 
-### USART
-Note that if you are using an **Arduino Uno**, USART work a little different; If you set the baudrate to `57600` for example, the baudrate you'll have to listen for in your terminal will become double the rate you've set in the code, so that's `115200`. This is because the Uno runs on `Asynchronous Double Speed Mode` by default. 
+- Since the Arduino Uno has a quirk where Double Speed Asynchronous Mode for USART is enabled by default, we made sure to disable this. If this mode is enabled it means that the USART baud rate is doubled, so if you were using a baud rate of `9200` in the code, you'd have to use a baud rate of 19200 in your terminal. We disabled this to keep things consistent, and because it has no real benefit. If you wish to turn this on however, you can do so by using `usart_set_2x(true);`

--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ created by the compiler before linking) to the `OBJS` list in the Makefile.
 - Similarly, if you *add a new folder with header files*, add it to `INCL_DIRS`.
 - In case you need `printf` (or `printf` with floats), enable the appropriate LD_FLAGS
   in the Makefile (it's well commented). Code size will - obviously - grow quite a bit.
+
+## Notes
+
+### USART
+Note that if you are using an **Arduino Uno**, USART work a little different; If you set the baudrate to `57600` for example, the baudrate you'll have to listen for in your terminal will become double the rate you've set in the code, so that's `115200`. This is because the Uno runs on `Asynchronous Double Speed Mode` by default. 

--- a/lib/usart.c
+++ b/lib/usart.c
@@ -19,10 +19,22 @@ void usart_init(uint16_t ubrr)
 	// Enable Rx and Tx
 	UCSR0B = (1 << RXEN0) | (1 << TXEN0);
 
+	// Clear U2X0
+	cbi(UCSR0A, U2X0);
+
 	// 8-bit data, 1 stop bit
 	UCSR0C = (0b11 << UCSZ00);
 }
 
+void usart_set_2x(bool set) 
+{
+	// Turn on Double Speed Asynchronous Mode
+	if (set)
+		sbi(UCSR0A, U2X0);
+	// Turn off Double Speed Asynchronous Mode
+	else
+		cbi(UCSR0A, U2X0);
+}
 
 /** Send byte over USART */
 void usart_tx(uint8_t data)

--- a/lib/usart.h
+++ b/lib/usart.h
@@ -35,6 +35,9 @@ enum {
 /** Init UART with a UBRR value - can use the BAUD_* constants for 16 MHz */
 void usart_init(uint16_t ubrr);
 
+/** Set Double Speed Asynchronous mode on or off */
+void usart_set_2x(bool set);
+
 /** Check if there's a byte in the RX register */
 #define usart_rx_ready() bit_is_high(UCSR0A, RXC0)
 


### PR DESCRIPTION
Because the Arduino Uno's bootloader has Double Speed Asynchronous Mode enabled by default, I made sure to disable this so it's consistent with the other boards.
